### PR TITLE
spelling

### DIFF
--- a/include/funcube/fcdpp.h
+++ b/include/funcube/fcdpp.h
@@ -17,7 +17,7 @@ namespace funcube {
 /*!
  * \brief Funcube Pro+ Dongle source block.
  *
- * This class provides a soure block for the Funcube Pro+ Dongle by wrapping the
+ * This class provides a source block for the Funcube Pro+ Dongle by wrapping the
  * alsa audio interface and the USB control interface of the Funcube Dongle
  * into one convenient source block.
  * The hadware audio device is autodetected by the card name. If more than one Pro+ are
@@ -46,7 +46,7 @@ public:
      *  \param freq The frequency in unit Hz
      *
      * Sets the frequency of the Funcube Dongle with Hz or Khz resolution
-     * depending on the unit paramater ( 1: Hz , 1000 Khz )
+     * depending on the unit parameter ( 1: Hz , 1000 Khz )
      * applying the frequency correction set by set_freq_corr().
      *
      */

--- a/python/bindings/fcdpp_python.cc
+++ b/python/bindings/fcdpp_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fcdpp.h)                                                   */
-/* BINDTOOL_HEADER_FILE_HASH(198a90ba9166488bea042906de2a2c97)                     */
+/* BINDTOOL_HEADER_FILE_HASH(ede7534140bd9b838979fc32f9d259c6)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Correct spelling errors flagged by Debian's lintian tool,
and update Python binding hash.

Signed-off-by: A. Maitland Bottoms <bottoms@debian.org>