### PR TITLE
remove leftover "six" usage

### DIFF
--- a/docs/doxygen/doxyxml/generated/compoundsuper.py
+++ b/docs/doxygen/doxyxml/generated/compoundsuper.py
@@ -12,8 +12,6 @@ import sys
 from xml.dom import minidom
 from xml.dom import Node
 
-import six
-
 
 #
 # User methods
@@ -69,7 +67,7 @@ def showIndent(outfile, level):
         outfile.write('    ')
 
 def quote_xml(inStr):
-    s1 = (isinstance(inStr, six.string_types) and inStr or
+    s1 = (isinstance(inStr, str) and inStr or
           '%s' % inStr)
     s1 = s1.replace('&', '&amp;')
     s1 = s1.replace('<', '&lt;')
@@ -77,7 +75,7 @@ def quote_xml(inStr):
     return s1
 
 def quote_attrib(inStr):
-    s1 = (isinstance(inStr, six.string_types) and inStr or
+    s1 = (isinstance(inStr, str) and inStr or
           '%s' % inStr)
     s1 = s1.replace('&', '&amp;')
     s1 = s1.replace('<', '&lt;')

--- a/docs/doxygen/doxyxml/generated/indexsuper.py
+++ b/docs/doxygen/doxyxml/generated/indexsuper.py
@@ -12,8 +12,6 @@ import sys
 from xml.dom import minidom
 from xml.dom import Node
 
-import six
-
 #
 # User methods
 #
@@ -68,7 +66,7 @@ def showIndent(outfile, level):
         outfile.write('    ')
 
 def quote_xml(inStr):
-    s1 = (isinstance(inStr, six.string_types) and inStr or
+    s1 = (isinstance(inStr, str) and inStr or
           '%s' % inStr)
     s1 = s1.replace('&', '&amp;')
     s1 = s1.replace('<', '&lt;')
@@ -76,7 +74,7 @@ def quote_xml(inStr):
     return s1
 
 def quote_attrib(inStr):
-    s1 = (isinstance(inStr, six.string_types) and inStr or
+    s1 = (isinstance(inStr, str) and inStr or
           '%s' % inStr)
     s1 = s1.replace('&', '&amp;')
     s1 = s1.replace('<', '&lt;')


### PR DESCRIPTION
Hi,

six is being removed: https://wiki.debian.org/Python3-six-removal


https://bugs.debian.org/cgi-bin/bugreport.cgi?archive=no&bug=1122420